### PR TITLE
Mod compat #2

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/amendments/configs/CommonConfigs.java
+++ b/common/src/main/java/net/mehvahdjukaar/amendments/configs/CommonConfigs.java
@@ -155,7 +155,7 @@ public class CommonConfigs {
         WALL_LANTERN_HIGH_PRIORITY = builder.comment("Gives high priority to wall lantern placement. Enable to override other wall lanterns placements, disable if it causes issues with other mods that use lower priority block click events")
                 .define("high_priority", true);
 
-        List<String> modBlacklist = Arrays.asList("bbb", "extlights", "betterendforge", "spelunkery", "galosphere", "tconstruct", "enigmaticlegacy", "beautify");
+        List<String> modBlacklist = Arrays.asList("bbb", "extlights", "betterendforge", "spelunkery", "galosphere", "tconstruct", "enigmaticlegacy", "beautify", "candlelight");
         WALL_LANTERN_BLACKLIST = builder.comment("Mod ids of mods that have lantern block that extend the base lantern class but don't look like one")
                 .define("mod_blacklist", modBlacklist);
         WALL_LANTERN_WHITELIST = builder.comment("Ids of blocks that are not detected as lanterns but should be")

--- a/common/src/main/resources/assets/amendments/lang/en_us.json
+++ b/common/src/main/resources/assets/amendments/lang/en_us.json
@@ -5,6 +5,7 @@
   "block.amendments.dye_cauldron": "Dye Cauldron",
   "block.amendments.tool_hook": "Tool Hook",
   "block.amendments.wall_lantern": "Wall Lantern",
+  "block.amendments.skull_pile": "Skull Pile",
   "item.minecraft.lingering_potion.effect.empty": "Lingering Mixed Potion",
   "item.minecraft.splash_potion.effect.empty": "Splash Mixed Potion",
   "item.minecraft.potion.effect.empty": "Mixed Potion",

--- a/common/src/main/resources/data/amendments/tags/items/non_stackable_heads.json
+++ b/common/src/main/resources/data/amendments/tags/items/non_stackable_heads.json
@@ -1,10 +1,14 @@
 {
   "replace": false,
   "values": [
+    "minecraft:dragon_head",
     {
       "id": "supplementaries:enderman_head",
       "required": false
     },
-    "minecraft:dragon_head"
+    {
+      "id": "#hybrid-aquatic:plushies",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
Quick overview:
* Added `#hybrid-aquatic:plushies` item tag to `#amendments:non_stackable_heads` item tag (the plushies have skull-like code it seems)
* Added `"candlelight"` to lantern blacklisted mods in the common config
* Added missing `block.amendments.skull_pile` lang