### PR TITLE
Fix Soul Fire'd compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,10 @@ allprojects {
             url = "https://maven.blamejared.com/"
         }
 
+        maven {
+            name = "Crystal Nest"
+            url = "https://maven.crystalnest.it"
+        }
     }
 
     tasks.withType(JavaCompile) {
@@ -197,7 +201,8 @@ ext{
             neo_version          : neo_version,
             neo_version_range    : neo_version_range,
             loader_version_range : loader_version_range,
-            moonlight_min_version: moonlight_min_version
+            moonlight_min_version: moonlight_min_version,
+            soul_fire_d_version  : soul_fire_d_version
     ]
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     modCompileOnly("curse.maven:farmers-delight-398521:5051242")
     modCompileOnly("curse.maven:scholar-961802:5214379")
     modCompileOnly("curse.maven:new-thin-air-878379:5068247")
-    modCompileOnly("curse.maven:soul-fire-d-662413:5448803")
+    modCompileOnly("it.crystalnest:soul-fire-d-common:$minecraft_min_version-$soul_fire_d_version")
     modCompileOnly("curse.maven:quark-243121:5093415")
     modCompileOnly("curse.maven:zeta-968868:5078215")
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     modCompileOnly("curse.maven:supplementaries-412082:5147147")
     modCompileOnly("curse.maven:farmers-delight-refabricated-993166:5215068")
     modCompileOnly("curse.maven:spelunkery-790530:5043881")
+    modCompileOnly("it.crystalnest:soul-fire-d-common:$minecraft_min_version-$soul_fire_d_version")
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,9 +49,4 @@ create_version = 0.5.1-f-build.1335
 registrate_version = 1.1.42
 flywheel_version =  1.20.1-0.6.10-7
 cca_version = 5.2.1
-
-
-
-
-
-
+soul_fire_d_version = 5.0.4

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     modCompileOnly("curse.maven:spelunkery-790530:5043883")
     modCompileOnly("curse.maven:scholar-961802:5214379")
     modCompileOnly("curse.maven:map-atlases-forge-519759:5307805")
-    modCompileOnly("curse.maven:soul-fire-d-662413:5448803")
+    modCompileOnly("it.crystalnest:soul-fire-d-fabric:$minecraft_min_version-$soul_fire_d_version")
     modCompileOnly("curse.maven:cobweb-968456:5441209")
     modCompileOnly("curse.maven:puzzles-lib-495476:5330447")
     modCompileOnly("curse.maven:new-thin-air-878379:5068247")

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -116,7 +116,6 @@ dependencies {
     modCompileOnly("curse.maven:scholar-961802:5214379")
     modCompileOnly("curse.maven:map-atlases-forge-519759:5307805")
     modCompileOnly("it.crystalnest:soul-fire-d-fabric:$minecraft_min_version-$soul_fire_d_version")
-    modCompileOnly("curse.maven:cobweb-968456:5441209")
     modCompileOnly("curse.maven:puzzles-lib-495476:5330447")
     modCompileOnly("curse.maven:new-thin-air-878379:5068247")
     modCompileOnly("com.jozufozu.flywheel:flywheel-forge-${flywheel_version}")


### PR DESCRIPTION
### Aim

This PR aims to fix #142 (originally opened [here](https://github.com/Crystal-Nest/soul-fire-d/issues/59)).  
It should also fix #94 for 1.21.x

### Summary

Fixed Soul Fire'd import and removed unnecessary Cobweb import.

To compile properly locally I had to make some other changes, specifically the Loom and Gradle versions and to Moonlight Lib import, but I didn't include them in the PR. For this reason, **please make sure everything works properly** with these changes.

I also hope I have targeted the right branch. If not, anyway the changes to apply should be the same.

### Details

- Added Crystal Nest Maven to `build.gradle`.
- Added Soul Fire'd version property to `gradle.properties`.
- Removed Soul Fire'd imports using CurseMaven in all `build.gradle`s.
- Removed unnecessary Cobweb import using CurseMaven.
- Added Soul Fire'd imports using Crystal Nest Maven in all `build.gradle`s.