### PR TITLE
Fix hanging signs that override getticker not swinging

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/amendments/mixins/SignBlockEntityMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/amendments/mixins/SignBlockEntityMixin.java
@@ -1,0 +1,35 @@
+package net.mehvahdjukaar.amendments.mixins;
+
+import net.mehvahdjukaar.amendments.common.ExtendedHangingSign;
+import net.mehvahdjukaar.amendments.configs.ClientConfigs;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SignBlockEntity.class)
+public abstract class SignBlockEntityMixin extends BlockEntity{
+    public SignBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
+        super(type, pos, blockState);
+    }
+
+    /**
+     * Swings hanging signs that override getTicker
+     */
+    @Inject(method = "tick", at = @At("HEAD"))
+    private static void amendments$swingingSign(Level level, BlockPos pos, BlockState state, SignBlockEntity sign, CallbackInfo ci){
+        if (sign.getType() == BlockEntityType.HANGING_SIGN) {
+            // We're already swinging via CeilingHangingSignBlockMixin
+            return;
+        }
+        if (level.isClientSide && ClientConfigs.SWINGING_SIGNS.get() && sign instanceof ExtendedHangingSign te) {
+            te.amendments$getExtension().clientTick(level, pos, state);
+        }
+    }
+}

--- a/common/src/main/resources/amendments-common.mixins.json
+++ b/common/src/main/resources/amendments-common.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "AbstractCauldronBlockMixin",
     "AbstractSkullBlockMixin",
+    "SignBlockEntityMixin",
     "BellMixin",
     "BellTileEntityMixin",
     "BlocksMixin",

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ neo_version_range = [47.1.0,)
 loader_version_range = [47,)
 
 # Other deps
-mixin_extras_version = 0.3.6
+mixin_extras_version = 0.4.1
 moonlight_version = 1.20-2.13.43
 required_moonlight_version = 1.20-2.13.43
 


### PR DESCRIPTION
### Issues Fixed
- Fixes #154
- Fixes https://github.com/team-abnormals/blueprint/issues/259
- Hanging Signs weren't calling SignBlockEntity::tick anymore

### Cause
https://github.com/MehVahdJukaar/amendments/blob/8d4135b67b8573a1c2b04363bb42c014358ec148/common/src/main/java/net/mehvahdjukaar/amendments/mixins/CeilingHangingSignBlockMixin.java#L76-L84 will only get applied if getTicker isn't overridden. Overriding this is necessary though as `SignBlockEntity::tick` will otherwise not get called due to comparing a modded block entity with one of the vanilla sign entities. And having a new block entity is necessary due to the valid blocks for the block entity. 
Not many mods override getTicker though; `SignBlockEntity::tick` resets the uuid that is currently editing if the player is moved away too far while editing, which would lock the sign from being edited by anyone else until the world was reloaded, and does nothing else, so I'm not surprised people forget it.

### Implemented Solution
Inject the swinging directly into `SignBlockEntity::tick`. This will swing all hanging signs that do override getTicker
Wrap getTicker with a swing as well. This will swing all hanging signs that don't override getTicker. Not doing this would break the swinging for almost every modded sign instead, which isn't desirable.
This would double swing vanilla signs as those don't actually have a mismatched BET, so just don't (:
