### PR TITLE
Allow Biomes o' Plenty's Glowing Moss Carpet to be put onto stairs

### DIFF
--- a/common/src/main/resources/data/amendments/tags/block/stairs_carpets.json
+++ b/common/src/main/resources/data/amendments/tags/block/stairs_carpets.json
@@ -11,7 +11,8 @@
     {"id":"quark:bamboo_mat","required":false},
     {"id":"farmersdelight:canvas_rug","required":false},
     {"id":"vanilla_backport:pale_moss_carpet","required":false},
-    {"id":"minecraft:pale_moss_carpet","required":false}
+    {"id":"minecraft:pale_moss_carpet","required":false},
+    {"id":"biomesoplenty:glowing_moss_carpet","required":false}
   ],
   "remove": [
     "hexerei:infused_fabric_carpet_ornate",


### PR DESCRIPTION
You'd think this would come naturally, but `#minecraft:moss_carpets` is not *normally* a tag in Minecraft `1.21.1` as the Pale Garden did not exist yet, so I wouldn't personally deem it an oversight from Biomes o' Plenty